### PR TITLE
add access_by_lua_call_prev directive

### DIFF
--- a/src/ngx_http_lua_common.h
+++ b/src/ngx_http_lua_common.h
@@ -184,6 +184,8 @@ struct ngx_http_lua_main_conf_s {
     ngx_flag_t           postponed_to_rewrite_phase_end;
     ngx_flag_t           postponed_to_access_phase_end;
 
+    ngx_flag_t           access_by_lua_call_prev;
+
     ngx_http_lua_main_conf_handler_pt    init_handler;
     ngx_str_t                            init_src;
 

--- a/src/ngx_http_lua_module.c
+++ b/src/ngx_http_lua_module.c
@@ -1126,6 +1126,9 @@ ngx_http_lua_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     } else if (lmcf->access_by_lua_call_prev && prev->access_handlers != NULL) {
         handlers = ngx_array_create(cf->pool, conf->access_handlers->nelts + prev->access_handlers->nelts,
                                     sizeof(ngx_http_lua_phase_handler_t));
+        if (handlers == NULL) {
+            return NGX_CONF_ERROR;
+        }
         ph = ngx_array_push_n(handlers, conf->access_handlers->nelts + prev->access_handlers->nelts);
         if (ph == NULL) {
             return NGX_CONF_ERROR;

--- a/t/024-access/dup-cmds.t
+++ b/t/024-access/dup-cmds.t
@@ -421,3 +421,58 @@ qr/access \d at \w+/
 --- grep_error_log_out
 access 1 at location
 access 2 at location
+
+
+
+=== TEST 19: multiple directives at different phase: http(Y) + server(Y) + location(Y)
+--- http_config
+    access_by_lua_call_prev  on;
+    access_by_lua_block { ngx.log(ngx.ERR, "access 1 at http") }
+    access_by_lua_block { ngx.log(ngx.ERR, "access 2 at http") }
+--- config
+    access_by_lua_block { ngx.log(ngx.ERR, "access 1 at server") }
+    access_by_lua_block { ngx.log(ngx.ERR, "access 2 at server") }
+
+    location = /t {
+        access_by_lua_block { ngx.log(ngx.ERR, "access 1 at location") }
+        access_by_lua_block { ngx.log(ngx.ERR, "access 2 at location") }
+        echo "Hello /t";
+    }
+--- request
+GET /t
+--- response_body
+Hello /t
+--- grep_error_log eval
+qr/access \d at \w+/
+--- grep_error_log_out
+access 1 at http
+access 2 at http
+access 1 at server
+access 2 at server
+access 1 at location
+access 2 at location
+
+
+
+=== TEST 20: multiple directives at different phase: http(Y) + server(Y) + location(Y)
+--- http_config
+    access_by_lua_call_prev  on;
+    access_by_lua_block { ngx.log(ngx.ERR, "access 1 at http") }
+    access_by_lua_block { ngx.log(ngx.ERR, "access 2 at http") }
+--- config
+    location = /t {
+        access_by_lua_block { ngx.log(ngx.ERR, "access 1 at location") }
+        access_by_lua_block { ngx.log(ngx.ERR, "access 2 at location") }
+        echo "Hello /t";
+    }
+--- request
+GET /t
+--- response_body
+Hello /t
+--- grep_error_log eval
+qr/access \d at \w+/
+--- grep_error_log_out
+access 1 at http
+access 2 at http
+access 1 at location
+access 2 at location


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.

Add new access_by_lua_call_prev directive. Call parent access handlers.

Sample config has been attached.

test: curl "http://localhost:8181/test" and check the error.log file.

[nginx.conf.zip](https://github.com/iresty/lua-nginx-module/files/691553/nginx.conf.zip)

.
